### PR TITLE
Make activity param optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ buildscript {
 Add the following to your app's build.gradle file:
 
 ```
-implementation 'com.authsignal:authsignal-android:2.2.9'
+implementation 'com.authsignal:authsignal-android:2.2.10'
 ```
 
 ## Initialization

--- a/module/gradle.properties
+++ b/module/gradle.properties
@@ -2,5 +2,5 @@ pomGroup=com.authsignal
 pomPackaging=aar
 pomName=Authsignal SDK for Android
 pomArtifactId=authsignal-android
-versionName=2.2.9
+versionName=2.2.10
 

--- a/module/src/main/java/com/authsignal/Authsignal.kt
+++ b/module/src/main/java/com/authsignal/Authsignal.kt
@@ -11,7 +11,7 @@ import com.authsignal.device.AuthsignalDevice
 class Authsignal(
   tenantID: String,
   baseURL: String,
-  activity: Activity
+  activity: Activity? = null
 ) {
   val passkey = AuthsignalPasskey(tenantID = tenantID, baseURL = baseURL, activity = activity)
   val push = AuthsignalPush(tenantID = tenantID, baseURL = baseURL)

--- a/module/src/main/java/com/authsignal/passkey/AuthsignalPasskey.kt
+++ b/module/src/main/java/com/authsignal/passkey/AuthsignalPasskey.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 class AuthsignalPasskey(
   tenantID: String,
   baseURL: String,
-  private val activity: Activity) {
+  private val activity: Activity?) {
   private val api = PasskeyAPI(tenantID, baseURL)
   private val manager = PasskeyManager(activity)
   private val passkeyLocalKey = "@as_passkey_credential_id"
@@ -27,6 +27,10 @@ class AuthsignalPasskey(
     preferImmediatelyAvailableCredentials: Boolean = true
   ): AuthsignalResponse<SignUpResponse> {
     val userToken = token ?: cache.token ?: return cache.handleTokenNotSetError()
+
+    if (activity == null) {
+      return PasskeySdkErrors.contextError()
+    }
 
     val optsResponse = api.registrationOptions(userToken, username, displayName)
 
@@ -91,6 +95,10 @@ class AuthsignalPasskey(
   ): AuthsignalResponse<SignInResponse> {
     val userToken = token ?: cache.token;
 
+    if (activity == null) {
+      return PasskeySdkErrors.contextError()
+    }
+
     val challengeId = action?.let {
       val challengeResponse = api.challenge(it)
 
@@ -152,6 +160,10 @@ class AuthsignalPasskey(
   }
 
   suspend fun isAvailableOnDevice(): AuthsignalResponse<Boolean> {
+    if (activity == null) {
+      return PasskeySdkErrors.contextError()
+    }
+
     val preferences = activity.getPreferences(Context.MODE_PRIVATE)
     val credentialId = preferences.getString(passkeyLocalKey, null)
       ?: return AuthsignalResponse(data = false)
@@ -166,6 +178,10 @@ class AuthsignalPasskey(
   }
 
   private fun getDefaultDeviceId(): String {
+    if (activity == null) {
+      return "";
+    }
+
     val preferences = activity.getPreferences(Context.MODE_PRIVATE)
     val defaultDeviceId = preferences.getString(defaultDeviceLocalKey, null)
 

--- a/module/src/main/java/com/authsignal/passkey/PasskeyManager.kt
+++ b/module/src/main/java/com/authsignal/passkey/PasskeyManager.kt
@@ -12,8 +12,12 @@ import kotlinx.serialization.decodeFromString
 
 private const val TAG = "com.authsignal.passkey"
 
-class PasskeyManager(private val context: Context) {
-  private val credentialManager = CredentialManager.create(context)
+class PasskeyManager(private val context: Context?) {
+  private val credentialManager: CredentialManager? =
+    if (context != null)
+      CredentialManager.create(context)
+    else
+      null
 
   private val json = Json { ignoreUnknownKeys = true }
 
@@ -21,6 +25,10 @@ class PasskeyManager(private val context: Context) {
     requestJson: String,
     preferImmediatelyAvailableCredentials: Boolean
   ): AuthsignalResponse<PasskeyRegistrationCredential> {
+    if (context == null || credentialManager == null) {
+      return PasskeySdkErrors.contextError()
+    }
+
     if (Build.VERSION.SDK_INT <= 28) {
       return AuthsignalResponse(
         error = "Passkey registration requires API version 28 or higher.",
@@ -57,6 +65,10 @@ class PasskeyManager(private val context: Context) {
   }
 
   suspend fun auth(requestJson: String, preferImmediatelyAvailableCredentials: Boolean): AuthsignalResponse<PasskeyAuthenticationCredential> {
+    if (context == null || credentialManager == null) {
+      return PasskeySdkErrors.contextError()
+    }
+
     val request = GetCredentialRequest(
       credentialOptions = listOf(GetPublicKeyCredentialOption(requestJson = requestJson)),
       preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials

--- a/module/src/main/java/com/authsignal/passkey/PasskeySdkErrors.kt
+++ b/module/src/main/java/com/authsignal/passkey/PasskeySdkErrors.kt
@@ -1,0 +1,12 @@
+package com.authsignal.passkey
+
+import com.authsignal.models.AuthsignalResponse
+
+object PasskeySdkErrors {
+  suspend fun <T>contextError(): AuthsignalResponse<T> {
+    return AuthsignalResponse(
+      error = "An activity param must be provided when initializing the SDK to use passkeys.",
+      errorCode = "sdk_error"
+    )
+  }
+}


### PR DESCRIPTION
### Bug Fixes
- Make activity param in SDK constructor optional - only required when using passkeys.

### Checklist
- [x] Version bumped