### PR TITLE
Persistence of default device ID for passkey auth

### DIFF
--- a/module/gradle.properties
+++ b/module/gradle.properties
@@ -2,4 +2,4 @@ pomGroup=com.authsignal
 pomPackaging=aar
 pomName=Authsignal SDK for Android
 pomArtifactId=authsignal-android
-versionName=2.3.0
+versionName=2.3.1

--- a/module/src/main/java/com/authsignal/passkey/AuthsignalPasskey.kt
+++ b/module/src/main/java/com/authsignal/passkey/AuthsignalPasskey.kt
@@ -193,7 +193,7 @@ class AuthsignalPasskey(
     val newDefaultDeviceId = UUID.randomUUID().toString()
 
     with (activity.getPreferences(Context.MODE_PRIVATE).edit()) {
-      putString(passkeyLocalKey, newDefaultDeviceId)
+      putString(defaultDeviceLocalKey, newDefaultDeviceId)
       apply()
     }
 


### PR DESCRIPTION
### Bug Fixes
- Fix persistence of default device ID for passkey auth

### Checklist
- [x] Version bumped