### PR TITLE
[AUT-3359] Use nonce instead of idempotency key, in attestation

### DIFF
--- a/module/gradle.properties
+++ b/module/gradle.properties
@@ -2,4 +2,4 @@ pomGroup=com.authsignal
 pomPackaging=aar
 pomName=Authsignal SDK for Android
 pomArtifactId=authsignal-android
-versionName=3.7.0
+versionName=3.8.0

--- a/module/src/main/java/com/authsignal/BaseAPI.kt
+++ b/module/src/main/java/com/authsignal/BaseAPI.kt
@@ -1,0 +1,46 @@
+package com.authsignal
+
+import com.authsignal.models.AuthsignalResponse
+import com.authsignal.models.ChallengeResponse
+import com.authsignal.models.api.ChallengeRequest
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+abstract class BaseAPI(tenantID: String, protected val baseURL: String) {
+  protected val client = HttpClientFactory.create()
+
+  protected val basicAuth = "Basic ${Encoder.toBase64String("$tenantID:".toByteArray())}"
+
+  suspend fun challenge(
+    action: String? = null,
+    token: String? = null,
+  ): AuthsignalResponse<ChallengeResponse> {
+    val url = "$baseURL/client/challenge"
+    val body = ChallengeRequest(action = action)
+
+    return try {
+      val response = client.post(url) {
+        contentType(ContentType.Application.Json)
+        setBody(body)
+
+        headers {
+          append(
+            HttpHeaders.Authorization,
+            if (token == null) basicAuth else "Bearer $token",
+          )
+        }
+      }
+
+      if (response.status == HttpStatusCode.OK) {
+        val data = response.body<ChallengeResponse>()
+
+        AuthsignalResponse(data = data)
+      } else {
+        APIError.mapToErrorResponse(response)
+      }
+    } catch (e: Exception) {
+      APIError.handleNetworkException(e)
+    }
+  }
+}

--- a/module/src/main/java/com/authsignal/inapp/AuthsignalInApp.kt
+++ b/module/src/main/java/com/authsignal/inapp/AuthsignalInApp.kt
@@ -2,7 +2,6 @@ package com.authsignal.inapp
 
 import android.content.Context
 import com.authsignal.DeviceUtils
-import com.authsignal.Encoder
 import com.authsignal.KeyManager
 import com.authsignal.PinManager
 import com.authsignal.SdkErrorCodes
@@ -62,10 +61,12 @@ class AuthsignalInApp(
     var deviceIntegrityToken: String? = null
 
     if (performAttestation) {
-      val nonce = Encoder.getJwtClaim(userToken, "idempotencyKey")
+      val challengeResponse = api.challenge(token = userToken)
+
+      val nonce = challengeResponse.data?.nonce
         ?: return AuthsignalResponse(
-          error = "Failed to extract idempotencyKey from token.",
-          errorCode = SdkErrorCodes.SdkError,
+          error = challengeResponse.error ?: "Failed to get nonce from challenge.",
+          errorCode = challengeResponse.errorCode ?: SdkErrorCodes.SdkError,
         )
 
       val integrityResponse = playIntegrityManager.requestToken(nonce)

--- a/module/src/main/java/com/authsignal/inapp/api/InAppAPI.kt
+++ b/module/src/main/java/com/authsignal/inapp/api/InAppAPI.kt
@@ -120,7 +120,10 @@ class InAppAPI(tenantID: String, private val baseURL: String) {
     }
   }
 
-  suspend fun challenge(action: String?): AuthsignalResponse<ChallengeResponse> {
+  suspend fun challenge(
+    action: String? = null,
+    token: String? = null,
+  ): AuthsignalResponse<ChallengeResponse> {
     val url = "$baseURL/client/challenge"
     val body = action?.let { ChallengeRequest(it) }
 
@@ -130,7 +133,10 @@ class InAppAPI(tenantID: String, private val baseURL: String) {
         setBody(body)
 
         headers {
-          append(HttpHeaders.Authorization, basicAuth)
+          append(
+            HttpHeaders.Authorization,
+            if (token == null) basicAuth else "Bearer $token",
+          )
         }
       }
 

--- a/module/src/main/java/com/authsignal/inapp/api/InAppAPI.kt
+++ b/module/src/main/java/com/authsignal/inapp/api/InAppAPI.kt
@@ -1,8 +1,8 @@
 package com.authsignal.inapp.api
 
 import com.authsignal.APIError
+import com.authsignal.BaseAPI
 import com.authsignal.Encoder
-import com.authsignal.HttpClientFactory
 import com.authsignal.inapp.api.models.InAppVerifyRequest
 import com.authsignal.inapp.api.models.InAppVerifyResponse
 import com.authsignal.models.AuthsignalResponse
@@ -12,10 +12,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 
-class InAppAPI(tenantID: String, private val baseURL: String) {
-  private val client = HttpClientFactory.create()
-
-  private val basicAuth = "Basic ${Encoder.toBase64String("$tenantID:".toByteArray())}"
+class InAppAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
 
   suspend fun getCredential(publicKey: String): AuthsignalResponse<AppCredential> {
     val encodedKey = Encoder.toBase64String(publicKey.toByteArray())
@@ -112,38 +109,6 @@ class InAppAPI(tenantID: String, private val baseURL: String) {
 
       return if (success) {
         AuthsignalResponse(data = true)
-      } else {
-        APIError.mapToErrorResponse(response)
-      }
-    } catch (e: Exception) {
-      APIError.handleNetworkException(e)
-    }
-  }
-
-  suspend fun challenge(
-    action: String? = null,
-    token: String? = null,
-  ): AuthsignalResponse<ChallengeResponse> {
-    val url = "$baseURL/client/challenge"
-    val body = action?.let { ChallengeRequest(it) }
-
-    return try {
-      val response = client.post(url) {
-        contentType(ContentType.Application.Json)
-        setBody(body)
-
-        headers {
-          append(
-            HttpHeaders.Authorization,
-            if (token == null) basicAuth else "Bearer $token",
-          )
-        }
-      }
-
-      if (response.status == HttpStatusCode.OK) {
-        val data = response.body<ChallengeResponse>()
-
-        AuthsignalResponse(data = data)
       } else {
         APIError.mapToErrorResponse(response)
       }

--- a/module/src/main/java/com/authsignal/models/ChallengeResponse.kt
+++ b/module/src/main/java/com/authsignal/models/ChallengeResponse.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ChallengeResponse(
   val challengeId: String,
+  val nonce: String? = null,
 )

--- a/module/src/main/java/com/authsignal/models/api/ChallengeRequest.kt
+++ b/module/src/main/java/com/authsignal/models/api/ChallengeRequest.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ChallengeRequest(
-  val action: String,
+  val action: String? = null,
 )

--- a/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
+++ b/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
@@ -59,7 +59,7 @@ class AuthsignalPush(
     var deviceIntegrityToken: String? = null
 
     if (performAttestation) {
-      val challengeResponse = api.challenge(userToken)
+      val challengeResponse = api.challenge(token = userToken)
 
       val nonce = challengeResponse.data?.nonce
         ?: return AuthsignalResponse(

--- a/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
+++ b/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
@@ -2,7 +2,6 @@ package com.authsignal.push
 
 import android.content.Context
 import com.authsignal.DeviceUtils
-import com.authsignal.Encoder
 import com.authsignal.KeyManager
 import com.authsignal.SdkErrorCodes
 import com.authsignal.Signer
@@ -60,10 +59,12 @@ class AuthsignalPush(
     var deviceIntegrityToken: String? = null
 
     if (performAttestation) {
-      val nonce = Encoder.getJwtClaim(userToken, "idempotencyKey")
+      val challengeResponse = api.challenge(userToken)
+
+      val nonce = challengeResponse.data?.nonce
         ?: return AuthsignalResponse(
-          error = "Failed to extract idempotencyKey from token.",
-          errorCode = SdkErrorCodes.SdkError,
+          error = challengeResponse.error ?: "Failed to get nonce from challenge.",
+          errorCode = challengeResponse.errorCode ?: SdkErrorCodes.SdkError,
         )
 
       val integrityResponse = playIntegrityManager.requestToken(nonce)

--- a/module/src/main/java/com/authsignal/push/api/PushAPI.kt
+++ b/module/src/main/java/com/authsignal/push/api/PushAPI.kt
@@ -1,18 +1,15 @@
 package com.authsignal.push.api
 
 import com.authsignal.APIError
+import com.authsignal.BaseAPI
 import com.authsignal.Encoder
-import com.authsignal.HttpClientFactory
 import com.authsignal.models.*
 import com.authsignal.models.api.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 
-class PushAPI(tenantID: String, private val baseURL: String) {
-  private val client = HttpClientFactory.create()
-
-  private val basicAuth = "Basic ${Encoder.toBase64String("$tenantID:".toByteArray())}"
+class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
 
   suspend fun getCredential(publicKey: String): AuthsignalResponse<AppCredential> {
     val encodedKey = Encoder.toBase64String(publicKey.toByteArray())
@@ -109,32 +106,6 @@ class PushAPI(tenantID: String, private val baseURL: String) {
 
       return if (success) {
         AuthsignalResponse(data = true)
-      } else {
-        APIError.mapToErrorResponse(response)
-      }
-    } catch (e: Exception) {
-      APIError.handleNetworkException(e)
-    }
-  }
-
-  suspend fun challenge(token: String): AuthsignalResponse<ChallengeResponse> {
-    val url = "$baseURL/client/challenge"
-    val body = ChallengeRequest(action = null)
-
-    return try {
-      val response = client.post(url) {
-        contentType(ContentType.Application.Json)
-        setBody(body)
-
-        headers {
-          append(HttpHeaders.Authorization, "Bearer $token")
-        }
-      }
-
-      if (response.status == HttpStatusCode.OK) {
-        val data = response.body<ChallengeResponse>()
-
-        AuthsignalResponse(data = data)
       } else {
         APIError.mapToErrorResponse(response)
       }

--- a/module/src/main/java/com/authsignal/push/api/PushAPI.kt
+++ b/module/src/main/java/com/authsignal/push/api/PushAPI.kt
@@ -117,6 +117,32 @@ class PushAPI(tenantID: String, private val baseURL: String) {
     }
   }
 
+  suspend fun challenge(token: String): AuthsignalResponse<ChallengeResponse> {
+    val url = "$baseURL/client/challenge"
+    val body = ChallengeRequest(action = null)
+
+    return try {
+      val response = client.post(url) {
+        contentType(ContentType.Application.Json)
+        setBody(body)
+
+        headers {
+          append(HttpHeaders.Authorization, "Bearer $token")
+        }
+      }
+
+      if (response.status == HttpStatusCode.OK) {
+        val data = response.body<ChallengeResponse>()
+
+        AuthsignalResponse(data = data)
+      } else {
+        APIError.mapToErrorResponse(response)
+      }
+    } catch (e: Exception) {
+      APIError.handleNetworkException(e)
+    }
+  }
+
   suspend fun getChallenge(publicKey: String): AuthsignalResponse<AppChallenge?> {
     val encodedKey = Encoder.toBase64String(publicKey.toByteArray())
     val url = "$baseURL/client/user-authenticators/push/challenge?publicKey=$encodedKey"

--- a/module/src/main/java/com/authsignal/qr/AuthsignalQRCode.kt
+++ b/module/src/main/java/com/authsignal/qr/AuthsignalQRCode.kt
@@ -58,7 +58,7 @@ class AuthsignalQRCode(
     var deviceIntegrityToken: String? = null
 
     if (performAttestation) {
-      val challengeResponse = api.challenge(userToken)
+      val challengeResponse = api.challenge(token = userToken)
 
       val nonce = challengeResponse.data?.nonce
         ?: return AuthsignalResponse(

--- a/module/src/main/java/com/authsignal/qr/AuthsignalQRCode.kt
+++ b/module/src/main/java/com/authsignal/qr/AuthsignalQRCode.kt
@@ -2,7 +2,6 @@ package com.authsignal.qr
 
 import android.content.Context
 import com.authsignal.DeviceUtils
-import com.authsignal.Encoder
 import com.authsignal.KeyManager
 import com.authsignal.SdkErrorCodes
 import com.authsignal.Signer
@@ -59,10 +58,12 @@ class AuthsignalQRCode(
     var deviceIntegrityToken: String? = null
 
     if (performAttestation) {
-      val nonce = Encoder.getJwtClaim(userToken, "idempotencyKey")
+      val challengeResponse = api.challenge(userToken)
+
+      val nonce = challengeResponse.data?.nonce
         ?: return AuthsignalResponse(
-          error = "Failed to extract idempotencyKey from token.",
-          errorCode = SdkErrorCodes.SdkError,
+          error = challengeResponse.error ?: "Failed to get nonce from challenge.",
+          errorCode = challengeResponse.errorCode ?: SdkErrorCodes.SdkError,
         )
 
       val integrityResponse = playIntegrityManager.requestToken(nonce)

--- a/module/src/main/java/com/authsignal/qr/api/QRCodeAPI.kt
+++ b/module/src/main/java/com/authsignal/qr/api/QRCodeAPI.kt
@@ -1,8 +1,8 @@
 package com.authsignal.qr.api
 
 import com.authsignal.APIError
+import com.authsignal.BaseAPI
 import com.authsignal.Encoder
-import com.authsignal.HttpClientFactory
 import com.authsignal.models.AuthsignalResponse
 import com.authsignal.models.api.*
 import com.authsignal.models.*
@@ -12,10 +12,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 
-class QRCodeAPI(tenantID: String, private val baseURL: String) {
-  private val client = HttpClientFactory.create()
-
-  private val basicAuth = "Basic ${Encoder.toBase64String("$tenantID:".toByteArray())}"
+class QRCodeAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
 
   suspend fun getCredential(publicKey: String): AuthsignalResponse<AppCredential> {
     val encodedKey = Encoder.toBase64String(publicKey.toByteArray())
@@ -112,32 +109,6 @@ class QRCodeAPI(tenantID: String, private val baseURL: String) {
 
       return if (success) {
         AuthsignalResponse(data = true)
-      } else {
-        APIError.mapToErrorResponse(response)
-      }
-    } catch (e: Exception) {
-      APIError.handleNetworkException(e)
-    }
-  }
-
-  suspend fun challenge(token: String): AuthsignalResponse<ChallengeResponse> {
-    val url = "$baseURL/client/challenge"
-    val body = ChallengeRequest(action = null)
-
-    return try {
-      val response = client.post(url) {
-        contentType(ContentType.Application.Json)
-        setBody(body)
-
-        headers {
-          append(HttpHeaders.Authorization, "Bearer $token")
-        }
-      }
-
-      if (response.status == HttpStatusCode.OK) {
-        val data = response.body<ChallengeResponse>()
-
-        AuthsignalResponse(data = data)
       } else {
         APIError.mapToErrorResponse(response)
       }

--- a/module/src/main/java/com/authsignal/qr/api/QRCodeAPI.kt
+++ b/module/src/main/java/com/authsignal/qr/api/QRCodeAPI.kt
@@ -120,6 +120,32 @@ class QRCodeAPI(tenantID: String, private val baseURL: String) {
     }
   }
 
+  suspend fun challenge(token: String): AuthsignalResponse<ChallengeResponse> {
+    val url = "$baseURL/client/challenge"
+    val body = ChallengeRequest(action = null)
+
+    return try {
+      val response = client.post(url) {
+        contentType(ContentType.Application.Json)
+        setBody(body)
+
+        headers {
+          append(HttpHeaders.Authorization, "Bearer $token")
+        }
+      }
+
+      if (response.status == HttpStatusCode.OK) {
+        val data = response.body<ChallengeResponse>()
+
+        AuthsignalResponse(data = data)
+      } else {
+        APIError.mapToErrorResponse(response)
+      }
+    } catch (e: Exception) {
+      APIError.handleNetworkException(e)
+    }
+  }
+
   suspend fun claimChallenge(
     challengeId: String,
     publicKey: String,


### PR DESCRIPTION
## Summary
- App Attest now signs the server-issued `nonce` from `POST /client/challenge` instead of extracting `idempotencyKey` from the user token.
- `/client/challenge` is now called with the user token so the server returns a `nonce`; `ChallengeResponse` gains an optional `nonce` field.
- Bumps version to 3.8.0 (requires matching server support for nonce-based attestation verification).