### PR TITLE
feat: accept optional pushToken on push enrollment

### DIFF
--- a/module/gradle.properties
+++ b/module/gradle.properties
@@ -2,4 +2,4 @@ pomGroup=com.authsignal
 pomPackaging=aar
 pomName=Authsignal SDK for Android
 pomArtifactId=authsignal-android
-versionName=3.8.0
+versionName=3.9.0

--- a/module/src/main/java/com/authsignal/models/api/AddAppCredentialRequest.kt
+++ b/module/src/main/java/com/authsignal/models/api/AddAppCredentialRequest.kt
@@ -8,6 +8,7 @@ data class AddAppCredentialRequest(
   val deviceName: String,
   val devicePlatform: String,
   val performAttestation: AddAppCredentialDeviceIntegrity? = null,
+  val pushToken: String? = null,
 )
 
 @Serializable

--- a/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
+++ b/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
@@ -40,6 +40,7 @@ class AuthsignalPush(
     timeout: Int = 0,
     authorizationType: Int = 0,
     performAttestation: Boolean = false,
+    pushToken: String? = null,
   ): AuthsignalResponse<AppCredential> {
     val userToken = token ?: TokenCache.shared.token ?: return TokenCache.shared.handleTokenNotSetError()
 
@@ -75,7 +76,7 @@ class AuthsignalPush(
       )
     }
 
-    return api.addCredential(userToken, publicKey, device, deviceIntegrityToken)
+    return api.addCredential(userToken, publicKey, device, deviceIntegrityToken, pushToken)
   }
 
   suspend fun removeCredential(signer: Signature? = null): AuthsignalResponse<Boolean> {

--- a/module/src/main/java/com/authsignal/push/api/PushAPI.kt
+++ b/module/src/main/java/com/authsignal/push/api/PushAPI.kt
@@ -45,7 +45,8 @@ class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
     token: String,
     publicKey: String,
     deviceName: String = "",
-    deviceIntegrityToken: String? = null): AuthsignalResponse<AppCredential> {
+    deviceIntegrityToken: String? = null,
+    pushToken: String? = null): AuthsignalResponse<AppCredential> {
     val url = "$baseURL/client/user-authenticators/push"
     val body = AddAppCredentialRequest(
       publicKey,
@@ -54,6 +55,7 @@ class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
       performAttestation = deviceIntegrityToken?.let {
         AddAppCredentialDeviceIntegrity(provider = "PLAY_INTEGRITY", token = it)
       },
+      pushToken = pushToken,
     )
 
     return try {


### PR DESCRIPTION
## Summary

Adds an optional `pushToken: String? = null` parameter to `AuthsignalPush.addCredential(...)` and threads it through `PushAPI.addCredential(...)` into the `AddAppCredentialRequest` body sent to `POST /v1/client/user-authenticators/push`.

