### PR TITLE
feat(push): resetExpiry flag + optional pushToken (AUT-3578)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ buildscript {
 Add the following to your app's build.gradle file:
 
 ```
-implementation 'com.authsignal:authsignal-android:4.1.0'
+implementation 'com.authsignal:authsignal-android:4.2.0'
 ```
 
 ## Initialization

--- a/module/gradle.properties
+++ b/module/gradle.properties
@@ -2,4 +2,4 @@ pomGroup=com.authsignal
 pomPackaging=aar
 pomName=Authsignal SDK for Android
 pomArtifactId=authsignal-android
-versionName=4.1.0
+versionName=4.2.0

--- a/module/src/main/java/com/authsignal/models/AppCredential.kt
+++ b/module/src/main/java/com/authsignal/models/AppCredential.kt
@@ -1,5 +1,8 @@
 package com.authsignal.models
 
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -8,4 +11,42 @@ data class AppCredential(
   val createdAt: String,
   val userId: String,
   val lastAuthenticatedAt: String? = null,
-)
+  val expiresAt: String? = null,
+) {
+  /**
+   * Whether the credential's lease has lapsed, based on [expiresAt].
+   *
+   * Fail-open: returns `false` when the server provides no expiry (no expiry
+   * configured) or when the value cannot be parsed, mirroring the server's
+   * fail-open behaviour.
+   */
+  val isExpired: Boolean
+    get() {
+      val expiry = expiresAt?.let { parseIso8601(it) } ?: return false
+
+      return expiry.before(Date())
+    }
+
+  private fun parseIso8601(value: String): Date? {
+    // Normalise to a form SimpleDateFormat can parse on API 23 (no java.time):
+    // "...Z" and "...+00:00" -> "...+0000".
+    val normalised = value
+      .replace("Z", "+0000")
+      .replace(Regex("([+-]\\d{2}):(\\d{2})$"), "$1$2")
+
+    val patterns = listOf(
+      "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+      "yyyy-MM-dd'T'HH:mm:ssZ",
+    )
+
+    for (pattern in patterns) {
+      try {
+        return SimpleDateFormat(pattern, Locale.US).parse(normalised)
+      } catch (_: Exception) {
+        // Try the next pattern.
+      }
+    }
+
+    return null
+  }
+}

--- a/module/src/main/java/com/authsignal/models/AppCredential.kt
+++ b/module/src/main/java/com/authsignal/models/AppCredential.kt
@@ -8,5 +8,5 @@ data class AppCredential(
   val createdAt: String,
   val userId: String,
   val lastAuthenticatedAt: String? = null,
-  val expiresAt: Long? = null,
+  val expiresAt: String? = null,
 )

--- a/module/src/main/java/com/authsignal/models/AppCredential.kt
+++ b/module/src/main/java/com/authsignal/models/AppCredential.kt
@@ -28,8 +28,13 @@ data class AppCredential(
     }
 
   private fun parseIso8601(value: String): Date? {
-    // Normalise to a form SimpleDateFormat can parse on API 23 (no java.time):
-    // "...Z" and "...+00:00" -> "...+0000".
+    // The server emits `expiresAt` via Luxon `DateTime.toISO()`, which yields
+    // fractional seconds plus a numeric timezone offset that includes a colon,
+    // e.g. "2026-06-30T12:42:38.416+12:00". minSdk is 23 with no core-library
+    // desugaring, so `java.time` is unavailable; `SimpleDateFormat`'s `Z` token
+    // does not accept a colon in the offset, so normalise before parsing:
+    //   - "...Z"      -> "...+0000"
+    //   - "...+12:00" -> "...+1200"
     val normalised = value
       .replace("Z", "+0000")
       .replace(Regex("([+-]\\d{2}):(\\d{2})$"), "$1$2")
@@ -41,7 +46,13 @@ data class AppCredential(
 
     for (pattern in patterns) {
       try {
-        return SimpleDateFormat(pattern, Locale.US).parse(normalised)
+        val formatter = SimpleDateFormat(pattern, Locale.US).apply {
+          // Reject malformed input rather than coercing it, so an unparseable
+          // value falls through to `null` (fail-open => not expired).
+          isLenient = false
+        }
+
+        return formatter.parse(normalised)
       } catch (_: Exception) {
         // Try the next pattern.
       }

--- a/module/src/main/java/com/authsignal/models/AppCredential.kt
+++ b/module/src/main/java/com/authsignal/models/AppCredential.kt
@@ -1,8 +1,6 @@
 package com.authsignal.models
 
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -11,53 +9,12 @@ data class AppCredential(
   val createdAt: String,
   val userId: String,
   val lastAuthenticatedAt: String? = null,
-  val expiresAt: String? = null,
+  val expiresAt: Long? = null,
 ) {
-  /**
-   * Whether the credential's lease has lapsed, based on [expiresAt].
-   *
-   * Fail-open: returns `false` when the server provides no expiry (no expiry
-   * configured) or when the value cannot be parsed, mirroring the server's
-   * fail-open behaviour.
-   */
   val isExpired: Boolean
     get() {
-      val expiry = expiresAt?.let { parseIso8601(it) } ?: return false
+      val expiresAt = expiresAt ?: return false
 
-      return expiry.before(Date())
+      return Date(expiresAt * 1000).before(Date())
     }
-
-  private fun parseIso8601(value: String): Date? {
-    // The server emits `expiresAt` via Luxon `DateTime.toISO()`, which yields
-    // fractional seconds plus a numeric timezone offset that includes a colon,
-    // e.g. "2026-06-30T12:42:38.416+12:00". minSdk is 23 with no core-library
-    // desugaring, so `java.time` is unavailable; `SimpleDateFormat`'s `Z` token
-    // does not accept a colon in the offset, so normalise before parsing:
-    //   - "...Z"      -> "...+0000"
-    //   - "...+12:00" -> "...+1200"
-    val normalised = value
-      .replace("Z", "+0000")
-      .replace(Regex("([+-]\\d{2}):(\\d{2})$"), "$1$2")
-
-    val patterns = listOf(
-      "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
-      "yyyy-MM-dd'T'HH:mm:ssZ",
-    )
-
-    for (pattern in patterns) {
-      try {
-        val formatter = SimpleDateFormat(pattern, Locale.US).apply {
-          // Reject malformed input rather than coercing it, so an unparseable
-          // value falls through to `null` (fail-open => not expired).
-          isLenient = false
-        }
-
-        return formatter.parse(normalised)
-      } catch (_: Exception) {
-        // Try the next pattern.
-      }
-    }
-
-    return null
-  }
 }

--- a/module/src/main/java/com/authsignal/models/AppCredential.kt
+++ b/module/src/main/java/com/authsignal/models/AppCredential.kt
@@ -1,6 +1,5 @@
 package com.authsignal.models
 
-import java.util.Date
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,11 +9,4 @@ data class AppCredential(
   val userId: String,
   val lastAuthenticatedAt: String? = null,
   val expiresAt: Long? = null,
-) {
-  val isExpired: Boolean
-    get() {
-      val expiresAt = expiresAt ?: return false
-
-      return Date(expiresAt * 1000).before(Date())
-    }
-}
+)

--- a/module/src/main/java/com/authsignal/models/api/AppCredentialResponse.kt
+++ b/module/src/main/java/com/authsignal/models/api/AppCredentialResponse.kt
@@ -8,5 +8,5 @@ data class AppCredentialResponse(
   val userId: String,
   val verifiedAt: String,
   val lastVerifiedAt: String? = null,
-  val expiresAt: String? = null,
+  val expiresAt: Long? = null,
 )

--- a/module/src/main/java/com/authsignal/models/api/AppCredentialResponse.kt
+++ b/module/src/main/java/com/authsignal/models/api/AppCredentialResponse.kt
@@ -8,4 +8,5 @@ data class AppCredentialResponse(
   val userId: String,
   val verifiedAt: String,
   val lastVerifiedAt: String? = null,
+  val expiresAt: String? = null,
 )

--- a/module/src/main/java/com/authsignal/models/api/AppCredentialResponse.kt
+++ b/module/src/main/java/com/authsignal/models/api/AppCredentialResponse.kt
@@ -8,5 +8,5 @@ data class AppCredentialResponse(
   val userId: String,
   val verifiedAt: String,
   val lastVerifiedAt: String? = null,
-  val expiresAt: Long? = null,
+  val expiresAt: String? = null,
 )

--- a/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialRequest.kt
+++ b/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialRequest.kt
@@ -7,5 +7,6 @@ data class UpdateAppCredentialRequest(
   val challengeId: String,
   val publicKey: String,
   val signature: String,
-  val pushToken: String,
+  val pushToken: String? = null,
+  val extend: Boolean = false,
 )

--- a/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialRequest.kt
+++ b/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialRequest.kt
@@ -8,5 +8,5 @@ data class UpdateAppCredentialRequest(
   val publicKey: String,
   val signature: String,
   val pushToken: String? = null,
-  val extend: Boolean = false,
+  val resetExpiry: Boolean = false,
 )

--- a/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialResponse.kt
+++ b/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialResponse.kt
@@ -7,7 +7,6 @@ data class UpdateAppCredentialResponse(
   val userAuthenticatorId: String,
   val userId: String,
   val lastVerifiedAt: String,
-  // Echoes the request's pushToken; absent for keep-alive calls that omit the token.
   val pushToken: String? = null,
-  val expiresAt: String? = null,
+  val expiresAt: Long? = null,
 )

--- a/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialResponse.kt
+++ b/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialResponse.kt
@@ -8,5 +8,5 @@ data class UpdateAppCredentialResponse(
   val userId: String,
   val lastVerifiedAt: String,
   val pushToken: String? = null,
-  val expiresAt: Long? = null,
+  val expiresAt: String? = null,
 )

--- a/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialResponse.kt
+++ b/module/src/main/java/com/authsignal/models/api/UpdateAppCredentialResponse.kt
@@ -7,5 +7,7 @@ data class UpdateAppCredentialResponse(
   val userAuthenticatorId: String,
   val userId: String,
   val lastVerifiedAt: String,
-  val pushToken: String,
+  // Echoes the request's pushToken; absent for keep-alive calls that omit the token.
+  val pushToken: String? = null,
+  val expiresAt: String? = null,
 )

--- a/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
+++ b/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
@@ -35,7 +35,8 @@ class AuthsignalPush(
   }
 
   suspend fun updateCredential(
-    pushToken: String,
+    pushToken: String? = null,
+    extend: Boolean = false,
     signer: Signature? = null
   ): AuthsignalResponse<UpdateAppCredentialResponse> {
     val publicKeyResponse = keyManager.getPublicKey()
@@ -77,7 +78,7 @@ class AuthsignalPush(
     val signature = signatureResponse.data
       ?: return AuthsignalResponse(error = signatureResponse.error)
 
-    return api.updateCredential(challengeId, publicKey, signature, pushToken)
+    return api.updateCredential(challengeId, publicKey, signature, pushToken, extend)
   }
 
   suspend fun addCredential(

--- a/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
+++ b/module/src/main/java/com/authsignal/push/AuthsignalPush.kt
@@ -36,7 +36,7 @@ class AuthsignalPush(
 
   suspend fun updateCredential(
     pushToken: String? = null,
-    extend: Boolean = false,
+    resetExpiry: Boolean = false,
     signer: Signature? = null
   ): AuthsignalResponse<UpdateAppCredentialResponse> {
     val publicKeyResponse = keyManager.getPublicKey()
@@ -78,7 +78,7 @@ class AuthsignalPush(
     val signature = signatureResponse.data
       ?: return AuthsignalResponse(error = signatureResponse.error)
 
-    return api.updateCredential(challengeId, publicKey, signature, pushToken, extend)
+    return api.updateCredential(challengeId, publicKey, signature, pushToken, resetExpiry)
   }
 
   suspend fun addCredential(

--- a/module/src/main/java/com/authsignal/push/api/PushAPI.kt
+++ b/module/src/main/java/com/authsignal/push/api/PushAPI.kt
@@ -30,6 +30,7 @@ class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
           credentialId = data.userAuthenticatorId,
           createdAt = data.verifiedAt,
           lastAuthenticatedAt = data.lastVerifiedAt,
+          expiresAt = data.expiresAt,
         )
 
         AuthsignalResponse(data = credential)
@@ -76,6 +77,7 @@ class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
           credentialId = data.userAuthenticatorId,
           createdAt = data.verifiedAt,
           lastAuthenticatedAt = data.lastVerifiedAt,
+          expiresAt = data.expiresAt,
         )
 
         AuthsignalResponse(data = credential)
@@ -208,10 +210,11 @@ class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
     challengeId: String,
     publicKey: String,
     signature: String,
-    pushToken: String,
+    pushToken: String? = null,
+    extend: Boolean = false,
   ): AuthsignalResponse<UpdateAppCredentialResponse> {
     val url = "$baseURL/client/user-authenticators/push"
-    val body = UpdateAppCredentialRequest(challengeId, publicKey, signature, pushToken)
+    val body = UpdateAppCredentialRequest(challengeId, publicKey, signature, pushToken, extend)
 
     return try {
       val response = client.patch(url) {

--- a/module/src/main/java/com/authsignal/push/api/PushAPI.kt
+++ b/module/src/main/java/com/authsignal/push/api/PushAPI.kt
@@ -211,10 +211,10 @@ class PushAPI(tenantID: String, baseURL: String) : BaseAPI(tenantID, baseURL) {
     publicKey: String,
     signature: String,
     pushToken: String? = null,
-    extend: Boolean = false,
+    resetExpiry: Boolean = false,
   ): AuthsignalResponse<UpdateAppCredentialResponse> {
     val url = "$baseURL/client/user-authenticators/push"
-    val body = UpdateAppCredentialRequest(challengeId, publicKey, signature, pushToken, extend)
+    val body = UpdateAppCredentialRequest(challengeId, publicKey, signature, pushToken, resetExpiry)
 
     return try {
       val response = client.patch(url) {


### PR DESCRIPTION
## What's new

Adds support for push credential expiry and keep-alive.

- `updateCredential` now takes an optional `pushToken` and a new `resetExpiry` flag:

  ```kotlin
  // Rotate the push token (existing behaviour, unchanged)
  authsignal.push.updateCredential(pushToken = token)

  // Keep-alive: reset the credential's expiry lease without changing the token
  authsignal.push.updateCredential(resetExpiry = true)
  ```

- When `pushToken` is omitted, the server keeps the stored token.
- `AppCredential` now exposes `expiresAt` (ISO timestamp), so you can check when the credential's lease lapses and re-enroll in time. Expired credentials are rejected by the server and cannot be revived.
- The `updateCredential` response now includes the refreshed `expiresAt`.

## Compatibility

`updateCredential("token")` calls work unchanged. One note: the parameter order is now `(pushToken, resetExpiry, signer)`, so if you pass a `signer`, use a named argument: `updateCredential(pushToken = token, signer = signer)`.

Ships as 4.2.0.

